### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ xgboost==1.6.0
 imbalanced-learn==0.9.1
 optuna==2.10.0
 plotly==5.5
-shap==0.41
+shap==0.42
 scikit-image==0.19
 pydicom-seg==0.4.1
 ipython==8.10.0


### PR DESCRIPTION
shap 0.42 has been released, and fixes many of the np.bool np.int deprecation bugs that now result in an error